### PR TITLE
BLOOM trigger that will activate the automation in Valkey-Extensions

### DIFF
--- a/.github/workflows/trigger-bloom-release
+++ b/.github/workflows/trigger-bloom-release
@@ -1,0 +1,39 @@
+name: Trigger Extension Update - Bloom
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version of Valkey Bloom module that was released
+        required: true
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine version
+        id: determine-vars
+        run: |
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            echo "Triggered by a release event."
+            VERSION=${{ github.event.release.tag_name }}
+          else
+            echo "Triggered manually."
+            VERSION=${{ inputs.version }}
+          fi
+
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Trigger extension update
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.EXTENSION_PAT }}
+          repository: ${{ github.repository_owner }}/valkey-extension
+          event-type: bloom-release
+          client-payload: >
+            {
+              "version": "${{ steps.determine-vars.outputs.version }}",
+              "module": "bloom"
+            }


### PR DESCRIPTION
We want to automate the valkey-extensions repository instead of having to manually update it. Tasks like version updates and Dockerfile modifications in the valkey-extensions repository are handled manually, leading to potential inconsistencies. The goal is to automate these processes through a pipeline that can handle version management, dynamic Dockerfile generation, and streamlined build workflows. 

This pull request is a trigger which will activate when a new version of Valkey-Bloom has been released (release candidate or GA). Once activated, it will send the version over to a workflow in the valkey-extensions repository which will then carry out all the processes listed above.